### PR TITLE
Add new method to get reading cancelling offsets

### DIFF
--- a/Adafruit_MMC56x3.cpp
+++ b/Adafruit_MMC56x3.cpp
@@ -188,6 +188,7 @@ bool Adafruit_MMC5603::getEvent(sensors_event_t *event) {
   /* Clear the event */
   memset(event, 0, sizeof(sensors_event_t));
 
+
   /* Read new data */
   if (!isContinuousMode()) {
     _ctrl0_reg->write(0x01); // TM_M trigger
@@ -222,6 +223,33 @@ bool Adafruit_MMC5603::getEvent(sensors_event_t *event) {
   event->magnetic.x = (float)x * 0.00625; // scale to uT by LSB in datasheet
   event->magnetic.y = (float)y * 0.00625;
   event->magnetic.z = (float)z * 0.00625;
+
+  return true;
+}
+
+bool Adafruit_MMC5603::getEventNoOffset(sensors_event_t *event) {
+  // 1) SET
+  _ctrl0_reg->write(0b1000);
+delay(10); // REQUIRED: t_SR = 1ms per datasheet
+
+  // 2) measure
+  sensors_event_t event1;
+  if (!getEvent(&event1)) return false;
+
+  // 3) RESET
+  _ctrl0_reg->write(0b1'0000);
+delay(10); // REQUIRED: t_SR = 1ms per datasheet  
+
+  // 4) measure
+  sensors_event_t event2;
+  if (!getEvent(&event2)) return false;
+
+  // 5) result is (r1 - r2) / 2
+
+  *event = event1;
+  event->magnetic.x = (event1.magnetic.x - event2.magnetic.x) / 2.0;
+  event->magnetic.y = (event1.magnetic.y - event2.magnetic.y) / 2.0;
+  event->magnetic.z = (event1.magnetic.z - event2.magnetic.z) / 2.0;
 
   return true;
 }

--- a/Adafruit_MMC56x3.cpp
+++ b/Adafruit_MMC56x3.cpp
@@ -227,10 +227,11 @@ bool Adafruit_MMC5603::getEvent(sensors_event_t *event) {
   return true;
 }
 
-bool Adafruit_MMC5603::getEventNoOffset(sensors_event_t *event) {
+bool Adafruit_MMC5603::getEventNoOffset(sensors_event_t *event)
+{
   // 1) SET
   _ctrl0_reg->write(0b1000);
-delay(10); // REQUIRED: t_SR = 1ms per datasheet
+  delay(1); // REQUIRED: t_SR = 1ms per datasheet
 
   // 2) measure
   sensors_event_t event1;
@@ -238,14 +239,13 @@ delay(10); // REQUIRED: t_SR = 1ms per datasheet
 
   // 3) RESET
   _ctrl0_reg->write(0b1'0000);
-delay(10); // REQUIRED: t_SR = 1ms per datasheet  
+  delay(1); // REQUIRED: t_SR = 1ms per datasheet
 
   // 4) measure
   sensors_event_t event2;
   if (!getEvent(&event2)) return false;
 
-  // 5) result is (r1 - r2) / 2
-
+  // 5) result is (e1 - e2) / 2
   *event = event1;
   event->magnetic.x = (event1.magnetic.x - event2.magnetic.x) / 2.0;
   event->magnetic.y = (event1.magnetic.y - event2.magnetic.y) / 2.0;

--- a/Adafruit_MMC56x3.cpp
+++ b/Adafruit_MMC56x3.cpp
@@ -237,7 +237,7 @@ bool Adafruit_MMC5603::getEventNoOffset(sensors_event_t *event)
   if (!getEvent(&event1)) return false;
 
   // 3) RESET
-  _ctrl0_reg->write(0b1'0000);
+  _ctrl0_reg->write(0b10000);
   delay(1); // REQUIRED: t_SR = 1ms per datasheet
 
   // 4) measure

--- a/Adafruit_MMC56x3.cpp
+++ b/Adafruit_MMC56x3.cpp
@@ -188,7 +188,6 @@ bool Adafruit_MMC5603::getEvent(sensors_event_t *event) {
   /* Clear the event */
   memset(event, 0, sizeof(sensors_event_t));
 
-
   /* Read new data */
   if (!isContinuousMode()) {
     _ctrl0_reg->write(0x01); // TM_M trigger

--- a/Adafruit_MMC56x3.h
+++ b/Adafruit_MMC56x3.h
@@ -61,6 +61,7 @@ public:
   bool begin(uint8_t i2c_addr = MMC56X3_DEFAULT_ADDRESS, TwoWire *wire = &Wire);
 
   bool getEvent(sensors_event_t *);
+  bool getEventNoOffset(sensors_event_t *event);
   void getSensor(sensor_t *);
 
   void reset(void);

--- a/Adafruit_MMC56x3.h
+++ b/Adafruit_MMC56x3.h
@@ -61,6 +61,9 @@ public:
   bool begin(uint8_t i2c_addr = MMC56X3_DEFAULT_ADDRESS, TwoWire *wire = &Wire);
 
   bool getEvent(sensors_event_t *);
+  // Like getEvent, but measures and removes the internal offset first.
+  // See: USING SET AND RESET TO REMOVE BRIDGE OFFSET
+  // In the datasheet.
   bool getEventNoOffset(sensors_event_t *event);
   void getSensor(sensor_t *);
 


### PR DESCRIPTION
The default output of this sensor has a lot of offsets, but it also has a section in the datasheet describing how to take a measurement removing said offsets. This function implements that method.
